### PR TITLE
Add japser as a dependency

### DIFF
--- a/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -14,11 +14,15 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -14,11 +14,15 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -14,11 +14,15 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -14,11 +14,15 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 numpy:
 - '1.19'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -14,11 +14,15 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 numpy:
 - '1.19'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.6.____cpython.yaml
@@ -5,13 +5,15 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 macos_machine:
@@ -19,6 +21,8 @@ macos_machine:
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.7.____cpython.yaml
@@ -5,13 +5,15 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 macos_machine:
@@ -19,6 +21,8 @@ macos_machine:
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.18python3.8.____cpython.yaml
@@ -5,13 +5,15 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 macos_machine:
@@ -19,6 +21,8 @@ macos_machine:
 numpy:
 - '1.18'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.7.____73_pypy.yaml
@@ -5,13 +5,15 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 macos_machine:
@@ -19,6 +21,8 @@ macos_machine:
 numpy:
 - '1.19'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -5,13 +5,15 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+jasper:
+- '1'
 libnetcdf:
 - 4.8.1
 macos_machine:
@@ -19,6 +21,8 @@ macos_machine:
 numpy:
 - '1.19'
 pin_run_as_build:
+  jasper:
+    max_pin: x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-fix_extension_config.patch
 
 build:
-  number: 4
+  number: 5
   skip: True  # [win]
 
 requirements:
@@ -28,6 +28,7 @@ requirements:
     - libnetcdf * nompi_*
     - cdat_info
     - libdrs_f
+    - jasper
 
   run:
     - python
@@ -37,6 +38,7 @@ requirements:
     - cdat_info
     - libdrs_f
     - {{ pin_compatible('numpy') }}
+    - jasper
 
 test:
   imports:


### PR DESCRIPTION
It seems clear from failing imports that cdtime depends on jasper
and therefore doesn't work with jasper 2 when built with jasper 1.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
